### PR TITLE
Block put

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -499,3 +499,41 @@ func (s *Shell) BlockStat(path string) (string, int, error) {
 
 	return inf.Key, inf.Size, nil
 }
+
+func (s *Shell) BlockPut(r io.Reader) (string, int, error) {
+	var rc io.ReadCloser
+	if rclose, ok := r.(io.ReadCloser); ok {
+		rc = rclose
+	} else {
+		rc = ioutil.NopCloser(r)
+	}
+
+	// handler expects an array of files
+	fr := files.NewReaderFile("", "", rc, nil)
+	slf := files.NewSliceFile("", "", []files.File{fr})
+	fileReader := files.NewMultiFileReader(slf, true)
+
+	req := NewRequest(s.url, "block/put")
+	req.Body = fileReader
+
+	resp, err := req.Send(s.httpcli)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Close()
+	if resp.Error != nil {
+		return "", 0, resp.Error
+	}
+
+	var inf struct {
+		Key  string
+		Size int
+	}
+
+	err = json.NewDecoder(resp.Output).Decode(&inf)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return inf.Key, inf.Size, nil
+}

--- a/shell.go
+++ b/shell.go
@@ -338,8 +338,8 @@ func (s *Shell) Refs(hash string, recursive bool) (<-chan string, error) {
 }
 
 func (s *Shell) Patch(root, action string, args ...string) (string, error) {
-	cmdargs := append([]string{root}, args...)
-	resp, err := s.newRequest("object/patch/"+action, cmdargs...).Send(s.httpcli)
+	cmdargs := append([]string{root, action}, args...)
+	resp, err := s.newRequest("object/patch", cmdargs...).Send(s.httpcli)
 	if err != nil {
 		return "", err
 	}
@@ -360,9 +360,9 @@ func (s *Shell) Patch(root, action string, args ...string) (string, error) {
 }
 
 func (s *Shell) PatchLink(root, path, childhash string, create bool) (string, error) {
-	cmdargs := []string{root, path, childhash}
+	cmdargs := []string{root, "add-link", path, childhash}
 
-	req := s.newRequest("object/patch/add-link", cmdargs...)
+	req := s.newRequest("object/patch", cmdargs...)
 	if create {
 		req.Opts["create"] = "true"
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ipfs/go-ipfs-shell"
 
-	u "github.com/ipfs/go-ipfs/util"
+	u "github.com/ipfs/go-ipfs-util"
 )
 
 var sh *shell.Shell


### PR DESCRIPTION
Helper to add block to ipfs through API.
uses route /block/put to add block to ipfs. returns hash, size and error.