### PR TITLE
Fill out Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This will download the source into `$GOPATH/src/github.com/ipfs/go-ipfs-api`.
 
 ## Usage
 
-...
+See [the godocs](https://godoc.org/github.com/ipfs/go-ipfs-api) for details on available methods. This should match the specs at [ipfs/specs](https://github.com/ipfs/specs/tree/master/api); however, there are still some methods which are not accounted for. If you would like to add any of them, see the contribute section below.
 
 ## Contribute
 


### PR DESCRIPTION
While I could list all of the available methods, I think that the GoDocs already do this fairly well and I would be duplicating data. However, a tracking issue with all of the methods that are needed would be ace. Shall I set one of those up?

I also point to the spec here. If someone points me to a Go package with a good Usage and API section, I am happy to fill this out more; however, I am not sure how else to best go forth with filling this section out.

Related to https://github.com/ipfs/go-ipfs-api/issues/13 and https://github.com/ipfs/go-ipfs-api/issues/15. 
