### PR TITLE
Proper Pubsub support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 before_install:
 - docker pull ipfs/go-ipfs:master
 - mkdir /tmp/ipfs && chmod 0777 /tmp/ipfs
-- docker run -d -v /tmp/ipfs:/data/ipfs -p 8080:8080 -p 4001:4001 -p 5001:5001 ipfs/go-ipfs:master
+- docker run -d -v /tmp/ipfs:/data/ipfs -p 8080:8080 -p 4001:4001 -p 5001:5001 ipfs/go-ipfs:master --enable-pubsub-experiment
 
 install:
   - go get -t -v ./...

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,0 +1,236 @@
+package shell
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"sync"
+)
+
+type b64String string
+
+func (bs *b64String) UnmarshalJSON(in []byte) error {
+	var b64 string
+
+	err := json.Unmarshal(in, &b64)
+	if err != nil {
+		return err
+	}
+
+	bsStr, err := base64.StdEncoding.DecodeString(b64)
+
+	*bs = b64String(bsStr)
+	return err
+}
+
+func (bs *b64String) Marshal() (string, error) {
+	jsonBytes, err := json.Marshal(
+		base64.StdEncoding.EncodeToString(
+			[]byte(*bs)))
+
+	return string(jsonBytes), err
+}
+
+///
+
+type PubSubRecord struct {
+	From     string    `json:"from"`
+	Data     b64String `json:"data"`
+	SeqNo    b64String `json:"seqno"`
+	TopicIDs []string  `json:"topicIDs"`
+}
+
+///
+
+type Subscription struct {
+	topic string
+	ch    chan *PubSubRecord
+}
+
+func newSubscription(topic string, ch chan *PubSubRecord) *Subscription {
+	return &Subscription{
+		topic: topic,
+		ch:    ch,
+	}
+}
+
+func (s *Subscription) Next() *PubSubRecord {
+	return <-s.ch
+}
+
+func (s *Subscription) Topic() string {
+	return s.topic
+}
+
+///
+
+type subscriptionHandler struct {
+	topic string
+	resp  *Response
+
+	readers map[chan *PubSubRecord]struct{}
+
+	stop      chan struct{}
+	add, drop chan chan *PubSubRecord
+
+	failReason error
+}
+
+func newSubscriptionHandler(topic string, resp *Response) *subscriptionHandler {
+	sh := &subscriptionHandler{
+		// the topic that is being handled
+		topic: topic,
+		// stop shuts down the subscription handler.
+		stop: make(chan struct{}),
+		// readers is the set of listeners
+		readers: make(map[chan *PubSubRecord]struct{}),
+		//add is the channel in which you add more listeners
+		add: make(chan chan *PubSubRecord),
+		//drop is the channel to which you send channels
+		drop: make(chan chan *PubSubRecord),
+		resp: resp,
+	}
+
+	go sh.work()
+
+	return sh
+}
+
+func (sh *subscriptionHandler) work() {
+	readOne := func(ch chan *PubSubRecord, errCh chan error) {
+		d := json.NewDecoder(sh.resp.Output)
+		if sh.resp.Error != nil {
+			errCh <- sh.resp.Error
+			return
+		}
+
+		r := PubSubRecord{}
+		err := d.Decode(&r)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		ch <- &r
+	}
+
+	ch := make(chan *PubSubRecord)
+	errCh := make(chan error)
+
+	go readOne(ch, errCh)
+
+L:
+	for {
+		select {
+		// remove a rdCh from pool
+		case ch := <-sh.drop:
+			delete(sh.readers, ch)
+
+			if len(sh.readers) == 0 {
+				break L
+			}
+
+		// add a rdCh to pool
+		case ch := <-sh.add:
+			sh.readers[ch] = struct{}{}
+
+		case r := <-ch:
+			for rdCh := range sh.readers {
+				rdCh <- r
+			}
+
+			go readOne(ch, errCh)
+
+		case err := <-errCh:
+			sh.failReason = err
+			break L
+
+		case <-sh.stop:
+			break L
+		}
+	}
+
+	for rdCh := range sh.readers {
+		delete(sh.readers, rdCh)
+		close(rdCh)
+	}
+
+	sh.resp.Output.Close()
+	sh = nil
+}
+
+func (sh *subscriptionHandler) Stop() {
+	sh.stop <- struct{}{}
+}
+
+func (sh *subscriptionHandler) Sub() *Subscription {
+	ch := make(chan *PubSubRecord)
+
+	sh.add <- ch
+
+	return newSubscription(sh.topic, ch)
+}
+
+func (sh *subscriptionHandler) Drop(s *Subscription) {
+	sh.drop <- s.ch
+}
+
+func (sh *subscriptionHandler) Error() error {
+	return sh.failReason
+}
+
+///
+
+type subscriptionManager struct {
+	sync.Mutex
+
+	s    *Shell
+	subs map[string]*subscriptionHandler
+}
+
+func newSubscriptionManager(s *Shell) *subscriptionManager {
+	return &subscriptionManager{
+		s:    s,
+		subs: make(map[string]*subscriptionHandler),
+	}
+}
+
+func (sm *subscriptionManager) Sub(topic string) (*Subscription, error) {
+	// lock
+	sm.Lock()
+	defer sm.Unlock()
+
+	// check if already subscribed
+	sh := sm.subs[topic]
+	if sh == nil { // if not, do so!
+		// connect
+		req := sm.s.newRequest("pubsub/sub", topic)
+		resp, err := req.Send(sm.s.httpcli)
+		if err != nil {
+			return nil, err
+		}
+
+		// pass connection to handler and add handler to manager
+		sh = newSubscriptionHandler(topic, resp)
+		sm.subs[topic] = sh
+	}
+
+	// success
+	return sh.Sub(), nil
+}
+
+func (sm *subscriptionManager) Drop(s *Subscription) {
+	sm.Lock()
+	defer sm.Unlock()
+
+	sh := sm.subs[s.topic]
+	if sh != nil {
+		sh.Drop(s)
+	}
+}
+
+func (sm *subscriptionManager) dropHandler(sh *subscriptionHandler) {
+	sm.Lock()
+	defer sm.Unlock()
+
+	delete(sm.subs, sh.topic)
+}

--- a/pubsub.go
+++ b/pubsub.go
@@ -3,7 +3,7 @@ package shell
 import (
 	"encoding/base64"
 	"encoding/json"
-	"sync"
+	//	"sync"
 )
 
 type b64String string
@@ -42,27 +42,35 @@ type PubSubRecord struct {
 ///
 
 type Subscription struct {
-	topic string
-	ch    chan *PubSubRecord
+	resp *Response
 }
 
-func newSubscription(topic string, ch chan *PubSubRecord) *Subscription {
+func newSubscription(resp *Response) *Subscription {
 	return &Subscription{
-		topic: topic,
-		ch:    ch,
+		resp: resp,
 	}
 }
 
-func (s *Subscription) Next() *PubSubRecord {
-	return <-s.ch
+func (s *Subscription) Next() (*PubSubRecord, error) {
+	if s.resp.Error != nil {
+		return nil, s.resp.Error
+	}
+
+	d := json.NewDecoder(s.resp.Output)
+
+	r := &PubSubRecord{}
+	err := d.Decode(r)
+
+	return r, err
 }
 
-func (s *Subscription) Topic() string {
-	return s.topic
+func (s *Subscription) Cancel() error {
+	return s.resp.Output.Close()
 }
 
 ///
 
+/*
 type subscriptionHandler struct {
 	topic string
 	resp  *Response
@@ -154,7 +162,7 @@ L:
 		close(rdCh)
 	}
 
-	sh.resp.Output.Close()
+	//sh.resp.Output.Close()
 	sh = nil
 }
 
@@ -234,3 +242,4 @@ func (sm *subscriptionManager) dropHandler(sh *subscriptionHandler) {
 
 	delete(sm.subs, sh.topic)
 }
+*/

--- a/shell.go
+++ b/shell.go
@@ -31,10 +31,7 @@ func NewShell(url string) *Shell {
 		},
 	}
 
-	s := NewShellWithClient(url, c)
-	//s.sm = newPubSubSubscriptionManager(s)
-
-	return s
+	return NewShellWithClient(url, c)
 }
 
 func NewShellWithClient(url string, c *gohttp.Client) *Shell {

--- a/shell.go
+++ b/shell.go
@@ -23,7 +23,7 @@ type Shell struct {
 	url     string
 	httpcli *gohttp.Client
 
-	sm *subscriptionManager
+	//sm *subscriptionManager
 }
 
 func NewShell(url string) *Shell {
@@ -34,7 +34,7 @@ func NewShell(url string) *Shell {
 	}
 
 	s := NewShellWithClient(url, c)
-	s.sm = newSubscriptionManager(s)
+	//s.sm = newSubscriptionManager(s)
 
 	return s
 }
@@ -695,11 +695,15 @@ func (s *Shell) ObjectPut(obj *IpfsObject) (string, error) {
 }
 
 func (s *Shell) PubSubSubscribe(topic string) (*Subscription, error) {
-	return s.sm.Sub(topic)
-}
+	// connect
+	req := s.newRequest("pubsub/sub", topic)
 
-func (s *Shell) PubSubCancelSubscription(sub *Subscription) {
-	s.sm.Drop(sub)
+	resp, err := req.Send(s.httpcli)
+	if err != nil {
+		return nil, err
+	}
+
+	return newSubscription(resp), nil
 }
 
 func (s *Shell) PubSubPublish(topic, data string) error {

--- a/shell.go
+++ b/shell.go
@@ -22,8 +22,6 @@ import (
 type Shell struct {
 	url     string
 	httpcli *gohttp.Client
-
-	//sm *subscriptionManager
 }
 
 func NewShell(url string) *Shell {
@@ -34,7 +32,7 @@ func NewShell(url string) *Shell {
 	}
 
 	s := NewShellWithClient(url, c)
-	//s.sm = newSubscriptionManager(s)
+	//s.sm = newPubSubSubscriptionManager(s)
 
 	return s
 }
@@ -694,7 +692,7 @@ func (s *Shell) ObjectPut(obj *IpfsObject) (string, error) {
 	return out.Hash, nil
 }
 
-func (s *Shell) PubSubSubscribe(topic string) (*Subscription, error) {
+func (s *Shell) PubSubSubscribe(topic string) (*PubSubSubscription, error) {
 	// connect
 	req := s.newRequest("pubsub/sub", topic)
 
@@ -703,16 +701,16 @@ func (s *Shell) PubSubSubscribe(topic string) (*Subscription, error) {
 		return nil, err
 	}
 
-	return newSubscription(resp), nil
+	return newPubSubSubscription(resp), nil
 }
 
 func (s *Shell) PubSubPublish(topic, data string) error {
-	resp, err := s.newRequest("pubsub/pub", topic, data).Send(s.httpcli)
+	_, err := s.newRequest("pubsub/pub", topic, data).Send(s.httpcli)
 	if err != nil {
 		return err
 	}
 
-	return resp.Error
+	return nil
 }
 
 func (s *Shell) DiagNet(format string) ([]byte, error) {

--- a/shell_test.go
+++ b/shell_test.go
@@ -145,8 +145,8 @@ func TestPubSub(t *testing.T) {
 	r, err := sub.Next()
 	t.Log("next: done. ")
 
-	is.NotNil(r)
 	is.Nil(err)
+	is.NotNil(r)
 	is.Equal(r.DataString(), "Hello World!")
 
 	sub2, err := s.PubSubSubscribe(topic)

--- a/shell_test.go
+++ b/shell_test.go
@@ -147,7 +147,7 @@ func TestPubSub(t *testing.T) {
 
 	is.Nil(err)
 	is.NotNil(r)
-	is.Equal(r.DataString(), "Hello World!")
+	is.Equal(r.Data(), "Hello World!")
 
 	sub2, err := s.PubSubSubscribe(topic)
 	is.Nil(err)
@@ -158,12 +158,12 @@ func TestPubSub(t *testing.T) {
 	r, err = sub2.Next()
 	is.Nil(err)
 	is.NotNil(r)
-	is.Equal(r.Data, "Hallo Welt!")
+	is.Equal(r.Data(), "Hallo Welt!")
 
 	r, err = sub.Next()
 	is.NotNil(r)
 	is.Nil(err)
-	is.Equal(r.Data, "Hallo Welt!")
+	is.Equal(r.Data(), "Hallo Welt!")
 
 	is.Nil(sub.Cancel())
 }


### PR DESCRIPTION
Recently I put a lot of effort into making things smooth on the server side. Here is the API code, that ignores the first packet sent because it is only used to force a flush.

Maybe the pubsub test should not be run if the server is not started with pubsub enabled? Don't know how to check that though.