### PR TITLE
shell.go: add ObjectStat support

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -710,6 +710,38 @@ func (s *Shell) PubSubPublish(topic, data string) error {
 	return nil
 }
 
+type ObjectStats struct {
+	Hash           string
+	BlockSize      int
+	CumulativeSize int
+	DataSize       int
+	LinksSize      int
+	NumLinks       int
+}
+
+// ObjectStat gets stats for the DAG object named by key. It returns
+// the stats of the requested Object or an error.
+func (s *Shell) ObjectStat(key string) (*ObjectStats, error) {
+	resp, err := s.newRequest("object/stat", key).Send(s.httpcli)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Close()
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	stat := &ObjectStats{}
+
+	err = json.NewDecoder(resp.Output).Decode(stat)
+	if err != nil {
+		return nil, err
+	}
+
+	return stat, nil
+}
+
 func (s *Shell) DiagNet(format string) ([]byte, error) {
 	var result = new(bytes.Buffer)
 

--- a/shell_test.go
+++ b/shell_test.go
@@ -167,3 +167,14 @@ func TestPubSub(t *testing.T) {
 
 	is.Nil(sub.Cancel())
 }
+
+func TestObjectStat(t *testing.T) {
+	obj := "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V"
+	is := is.New(t)
+	s := NewShell(shellUrl)
+	stat, err := s.ObjectStat("QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V")
+	is.Nil(err)
+	is.Equal(stat.Hash, obj)
+	is.Equal(stat.LinksSize, 3)
+	is.Equal(stat.CumulativeSize, 1688)
+}


### PR DESCRIPTION
I had this around since early october. Guess it doesn't hurt to upstream it.