### PR TITLE
Fixes for AddDir

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	files "github.com/whyrusleeping/go-multipart-files"
+	files "github.com/mikesun/go-multipart-files"
 )
 
 func (s *Shell) DagGet(ref string, out interface{}) error {

--- a/request.go
+++ b/request.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	files "github.com/whyrusleeping/go-multipart-files"
+	files "github.com/mikesun/go-multipart-files"
 )
 
 type Request struct {
@@ -82,7 +82,6 @@ func (r *Request) Send(c *http.Client) (*Response, error) {
 
 	if fr, ok := r.Body.(*files.MultiFileReader); ok {
 		req.Header.Set("Content-Type", "multipart/form-data; boundary="+fr.Boundary())
-		req.Header.Set("Content-Disposition", "form-data: name=\"files\"")
 	}
 
 	resp, err := c.Do(req)

--- a/shell.go
+++ b/shell.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
+	files "github.com/mikesun/go-multipart-files"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
-	files "github.com/whyrusleeping/go-multipart-files"
 	tar "github.com/whyrusleeping/tar-utils"
 )
 
@@ -200,7 +200,7 @@ func (s *Shell) AddDir(dir string) (string, error) {
 	reader := files.NewMultiFileReader(slf, true)
 
 	req := NewRequest(context.Background(), s.url, "add")
-	req.Opts["r"] = "true"
+	req.Opts["recursive"] = "true"
 	req.Body = reader
 
 	resp, err := req.Send(s.httpcli)


### PR DESCRIPTION
`AddDir` is using `github.com/whyrusleeping/go-multipart-files` to handle multi-part files, which uses recursive/nested multi-part MIME. The current IPFS API supports flattened, not recursive multi-part MIME as seen in `https://github.com/ipfs/go-ipfs/blob/master/commands/files/multipartfile.go` and `https://github.com/ipfs/go-ipfs/blob/master/commands/http/multifilereader.go`.

This PR uses https://github.com/whyrusleeping/go-multipart-files/pull/1 (modified fork of `github.com/whyrusleeping/go-multipart-files`) to match the current IPFS API's use of flattened multi-part MIME.