### PR TITLE
Shrink the dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "Qmar7ei5yhwt1oCExdR1QZQgQxYUuPFV5tsqvPNzaBpGjM",
-      "name": "floodsub",
-      "version": "0.8.20"
+      "hash": "Qmd1HfU1m9mR839VhGp5JrcvteF7b5LoTtPMqcxLuriCTY",
+      "name": "go-libp2p-pubsub",
+      "version": "0.1.0"
     },
     {
       "author": "whyrusleeping",

--- a/pubsub.go
+++ b/pubsub.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 
-	"github.com/libp2p/go-floodsub"
 	"github.com/libp2p/go-libp2p-peer"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )
 
 // PubSubRecord is a record received via PubSub.
@@ -23,8 +23,16 @@ type PubSubRecord interface {
 	TopicIDs() []string
 }
 
+type message struct {
+	*pb.Message
+}
+
+func (m *message) GetFrom() peer.ID {
+	return peer.ID(m.Message.GetFrom())
+}
+
 type floodsubRecord struct {
-	msg *floodsub.Message
+	msg *message
 }
 
 func (r floodsubRecord) From() peer.ID {
@@ -67,7 +75,7 @@ func (s *PubSubSubscription) Next() (PubSubRecord, error) {
 
 	d := json.NewDecoder(s.resp.Output)
 
-	r := &floodsub.Message{}
+	r := &message{}
 	err := d.Decode(r)
 
 	return floodsubRecord{msg: r}, err


### PR DESCRIPTION
By using the extracted pubsub protobufs from go-libp2p-pubsub