### PR TITLE
pubsub: undo workaround of skipping first message

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -63,7 +63,6 @@ func newPubSubSubscription(resp *Response) *PubSubSubscription {
 		resp: resp,
 	}
 
-	sub.Next() // skip empty element used for flushing
 	return sub
 }
 


### PR DESCRIPTION
Fixes pubsub after https://github.com/ipfs/go-ipfs/pull/4402 is in.

Before the commands rewrite we made go-ipfs send out the http response immediately by first sending an empty pubsub message. It was only there to force flushing the http connection. This message was discarded on the go-ipfs-api side.
Now go-ipfs uses the new cmds library. We can now properly flush and got rid of this hack. Therefore we mustn't drop the first message anymore.

@diasdavid I presume you'll have to make this change to js-ipfs-api as well?