### PR TITLE
Add http.ProxyFromEnvironment to the underlying http.Transport of Shell

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,0 +1,71 @@
+package shell
+
+import (
+	"context"
+	"encoding/json"
+)
+
+func (s *Shell) BootstrapAdd(peers []string) ([]string, error) {
+	resp, err := s.newRequest(context.Background(), "bootstrap/add", peers...).Send(s.httpcli)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Close()
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	addOutput := &struct {
+		Peers []string
+	}{}
+
+	err = json.NewDecoder(resp.Output).Decode(addOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	return addOutput.Peers, nil
+}
+
+func (s *Shell) BootstrapAddDefault() ([]string, error) {
+	resp, err := s.newRequest(context.Background(), "bootstrap/add/default").Send(s.httpcli)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Close()
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	addOutput := &struct {
+		Peers []string
+	}{}
+
+	err = json.NewDecoder(resp.Output).Decode(addOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	return addOutput.Peers, nil
+}
+
+func (s *Shell) BootstrapRmAll() ([]string, error) {
+	resp, err := s.newRequest(context.Background(), "bootstrap/rm/all").Send(s.httpcli)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Close()
+
+	rmAllOutput := &struct {
+		Peers []string
+	}{}
+
+	err = json.NewDecoder(resp.Output).Decode(rmAllOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	return rmAllOutput.Peers, nil
+}

--- a/shell.go
+++ b/shell.go
@@ -62,6 +62,7 @@ func NewLocalShell() *Shell {
 func NewShell(url string) *Shell {
 	c := &gohttp.Client{
 		Transport: &gohttp.Transport{
+			Proxy: gohttp.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},
 	}


### PR DESCRIPTION
Add http.ProxyFromEnvironment to the underlying http.Transport of Shell, in order to uses HTTP proxies as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables.