### PR TITLE
Add additional publish function for more fine grained control of IPNS record publishing

### DIFF
--- a/ipns.go
+++ b/ipns.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 type PublishResponse struct {
@@ -55,7 +54,6 @@ func (s *Shell) PublishWithDetails(contentHash string, lifetime string, ttl stri
 		resolveString = "false"
 	}
 	args := []string{contentHash, resolveString, lifetime, ttl, key}
-	fmt.Println("publishing to ipns")
 	resp, err := s.newRequest(context.TODO(), "name/publish", args...).Send(s.httpcli)
 	if err != nil {
 		return nil, err
@@ -65,7 +63,6 @@ func (s *Shell) PublishWithDetails(contentHash string, lifetime string, ttl stri
 	if resp.Error != nil {
 		return nil, resp.Error
 	}
-	fmt.Println("record published to ipns")
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Output)
 	json.Unmarshal(buf.Bytes(), &pubResp)

--- a/ipns.go
+++ b/ipns.go
@@ -42,8 +42,12 @@ func (s *Shell) PublishWithDetails(contentHash, key string, lifetime, ttl time.D
 		key = "self"
 	}
 	req.Opts["key"] = key
-	req.Opts["lifetime"] = lifetime.String()
-	req.Opts["ttl"] = ttl.String()
+	if lifetime.Seconds() > 0 {
+		req.Opts["lifetime"] = lifetime.String()
+	}
+	if ttl.Seconds() > 0 {
+		req.Opts["ttl"] = ttl.String()
+	}
 	req.Opts["resolve"] = strconv.FormatBool(resolve)
 	resp, err := req.Send(s.httpcli)
 	if err != nil {

--- a/ipns.go
+++ b/ipns.go
@@ -35,7 +35,7 @@ func (s *Shell) Publish(node string, value string) error {
 
 // PublishWithDetails is used for fine grained control over record publishing
 func (s *Shell) PublishWithDetails(contentHash, key string, lifetime, ttl time.Duration, resolve bool) (*PublishResponse, error) {
-	var pubResp PublishResponse
+	
 	args := []string{contentHash}
 	req := s.newRequest(context.Background(), "name/publish", args...)
 	if key == "" {
@@ -59,6 +59,7 @@ func (s *Shell) PublishWithDetails(contentHash, key string, lifetime, ttl time.D
 	}
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Output)
+	var pubResp PublishResponse
 	json.Unmarshal(buf.Bytes(), &pubResp)
 	return &pubResp, nil
 }

--- a/ipns.go
+++ b/ipns.go
@@ -35,7 +35,7 @@ func (s *Shell) Publish(node string, value string) error {
 
 // PublishWithDetails is used for fine grained control over record publishing
 func (s *Shell) PublishWithDetails(contentHash, key string, lifetime, ttl time.Duration, resolve bool) (*PublishResponse, error) {
-	
+
 	args := []string{contentHash}
 	req := s.newRequest(context.Background(), "name/publish", args...)
 	if key == "" {

--- a/ipns.go
+++ b/ipns.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"strconv"
 	"time"
 )
@@ -37,19 +36,16 @@ func (s *Shell) Publish(node string, value string) error {
 // PublishWithDetails is used for fine grained control over record publishing
 func (s *Shell) PublishWithDetails(contentHash, key string, lifetime, ttl time.Duration, resolve bool) (*PublishResponse, error) {
 	var pubResp PublishResponse
-	if contentHash == "" {
-		return nil, errors.New("empty contentHash provided")
-	}
-	args := make(map[string]string)
-	args["arg"] = contentHash
-	args["lifetime"] = lifetime.String()
-	args["ttl"] = ttl.String()
-	args["resolve"] = strconv.FormatBool(resolve)
+	args := []string{contentHash}
+	req := s.newRequest(context.Background(), "name/publish", args...)
 	if key == "" {
 		key = "self"
 	}
-	args["key"] = key
-	resp, err := s.newRequestIPNS(context.Background(), "name/publish", args).SendIPNS(s.httpcli)
+	req.Opts["key"] = key
+	req.Opts["lifetime"] = lifetime.String()
+	req.Opts["ttl"] = ttl.String()
+	req.Opts["resolve"] = strconv.FormatBool(resolve)
+	resp, err := req.Send(s.httpcli)
 	if err != nil {
 		return nil, err
 	}

--- a/ipns_test.go
+++ b/ipns_test.go
@@ -1,0 +1,37 @@
+package shell_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	ipfsapi "github.com/RTradeLtd/go-ipfs-api"
+)
+
+var examplesHash = "/ipfs/Qmbu7x6gJbsKDcseQv66pSbUcAA3Au6f7MfTYVXwvBxN2K"
+
+func TestPublishDetailsWithKey(t *testing.T) {
+	shell := ipfsapi.NewShell("localhost:5001")
+
+	resp, err := shell.PublishWithDetails(examplesHash, "self", time.Hour, time.Hour, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Value != examplesHash {
+		t.Fatalf(fmt.Sprintf("Expected to receive %s but got %s", examplesHash, resp.Value))
+	}
+}
+
+func TestPublishDetailsWithoutKey(t *testing.T) {
+	shell := ipfsapi.NewShell("localhost:5001")
+
+	resp, err := shell.PublishWithDetails(examplesHash, "", time.Hour, time.Hour, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Value != examplesHash {
+		t.Fatalf(fmt.Sprintf("Expected to receive %s but got %s", examplesHash, resp.Value))
+	}
+}

--- a/ipns_test.go
+++ b/ipns_test.go
@@ -1,37 +1,38 @@
-package shell_test
+package shell
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	ipfsapi "github.com/RTradeLtd/go-ipfs-api"
 )
 
-var examplesHash = "/ipfs/Qmbu7x6gJbsKDcseQv66pSbUcAA3Au6f7MfTYVXwvBxN2K"
+var examplesHashForIPNS = "/ipfs/Qmbu7x6gJbsKDcseQv66pSbUcAA3Au6f7MfTYVXwvBxN2K"
+var testKey = "self" // feel free to change to whatever key you have locally
 
 func TestPublishDetailsWithKey(t *testing.T) {
-	shell := ipfsapi.NewShell("localhost:5001")
+	t.Skip()
+	shell := NewShell("localhost:5001")
 
-	resp, err := shell.PublishWithDetails(examplesHash, "key1", time.Hour, time.Hour, false)
+	resp, err := shell.PublishWithDetails(examplesHashForIPNS, testKey, time.Second, time.Second, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if resp.Value != examplesHash {
+	if resp.Value != examplesHashForIPNS {
 		t.Fatalf(fmt.Sprintf("Expected to receive %s but got %s", examplesHash, resp.Value))
 	}
 }
 
 func TestPublishDetailsWithoutKey(t *testing.T) {
-	shell := ipfsapi.NewShell("localhost:5001")
+	t.Skip()
+	shell := NewShell("localhost:5001")
 
-	resp, err := shell.PublishWithDetails(examplesHash, "", time.Hour, time.Hour, false)
+	resp, err := shell.PublishWithDetails(examplesHashForIPNS, "", time.Second, time.Second, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if resp.Value != examplesHash {
+	if resp.Value != examplesHashForIPNS {
 		t.Fatalf(fmt.Sprintf("Expected to receive %s but got %s", examplesHash, resp.Value))
 	}
 }

--- a/ipns_test.go
+++ b/ipns_test.go
@@ -13,7 +13,7 @@ var examplesHash = "/ipfs/Qmbu7x6gJbsKDcseQv66pSbUcAA3Au6f7MfTYVXwvBxN2K"
 func TestPublishDetailsWithKey(t *testing.T) {
 	shell := ipfsapi.NewShell("localhost:5001")
 
-	resp, err := shell.PublishWithDetails(examplesHash, "self", time.Hour, time.Hour, false)
+	resp, err := shell.PublishWithDetails(examplesHash, "key1", time.Hour, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/request.go
+++ b/request.go
@@ -41,6 +41,33 @@ func NewRequest(ctx context.Context, url, command string, args ...string) *Reque
 	}
 }
 
+type RequestIPNS struct {
+	ApiBase string
+	Command string
+	Args    map[string]string
+	Opts    map[string]string
+	Body    io.Reader
+	Headers map[string]string
+}
+
+func NewRequestIPNS(ctx context.Context, url, command string, args map[string]string) *RequestIPNS {
+	if !strings.HasPrefix(url, "http") {
+		url = "http://" + url
+	}
+
+	opts := map[string]string{
+		"encoding":        "json",
+		"stream-channels": "true",
+	}
+	return &RequestIPNS{
+		ApiBase: url + "/api/v0",
+		Command: command,
+		Args:    args,
+		Opts:    opts,
+		Headers: make(map[string]string),
+	}
+}
+
 type Response struct {
 	Output io.ReadCloser
 	Error  *Error
@@ -74,7 +101,6 @@ func (e *Error) Error() string {
 
 func (r *Request) Send(c *http.Client) (*Response, error) {
 	url := r.getURL()
-
 	req, err := http.NewRequest("POST", url, r.Body)
 	if err != nil {
 		return nil, err
@@ -138,6 +164,79 @@ func (r *Request) getURL() string {
 	values := make(url.Values)
 	for _, arg := range r.Args {
 		values.Add("arg", arg)
+	}
+	for k, v := range r.Opts {
+		values.Add(k, v)
+	}
+
+	return fmt.Sprintf("%s/%s?%s", r.ApiBase, r.Command, values.Encode())
+}
+
+func (r *RequestIPNS) SendIPNS(c *http.Client) (*Response, error) {
+	url := r.getURLIPNS()
+	req, err := http.NewRequest("POST", url, r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if fr, ok := r.Body.(*files.MultiFileReader); ok {
+		req.Header.Set("Content-Type", "multipart/form-data; boundary="+fr.Boundary())
+		req.Header.Set("Content-Disposition", "form-data: name=\"files\"")
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	parts := strings.Split(contentType, ";")
+	contentType = parts[0]
+
+	nresp := new(Response)
+
+	nresp.Output = resp.Body
+	if resp.StatusCode >= http.StatusBadRequest {
+		e := &Error{
+			Command: r.Command,
+		}
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			e.Message = "command not found"
+		case contentType == "text/plain":
+			out, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ipfs-shell: warning! response read error: %s\n", err)
+			}
+			e.Message = string(out)
+		case contentType == "application/json":
+			if err = json.NewDecoder(resp.Body).Decode(e); err != nil {
+				fmt.Fprintf(os.Stderr, "ipfs-shell: warning! response unmarshall error: %s\n", err)
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "ipfs-shell: warning! unhandled response encoding: %s", contentType)
+			out, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ipfs-shell: response read error: %s\n", err)
+			}
+			e.Message = fmt.Sprintf("unknown ipfs-shell error encoding: %q - %q", contentType, out)
+		}
+		nresp.Error = e
+		nresp.Output = nil
+
+		// drain body and close
+		ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+
+	return nresp, nil
+}
+
+func (r *RequestIPNS) getURLIPNS() string {
+
+	values := make(url.Values)
+	for k, arg := range r.Args {
+		values.Add(k, arg)
 	}
 	for k, v := range r.Opts {
 		values.Add(k, v)

--- a/request.go
+++ b/request.go
@@ -41,33 +41,6 @@ func NewRequest(ctx context.Context, url, command string, args ...string) *Reque
 	}
 }
 
-type RequestIPNS struct {
-	ApiBase string
-	Command string
-	Args    map[string]string
-	Opts    map[string]string
-	Body    io.Reader
-	Headers map[string]string
-}
-
-func NewRequestIPNS(ctx context.Context, url, command string, args map[string]string) *RequestIPNS {
-	if !strings.HasPrefix(url, "http") {
-		url = "http://" + url
-	}
-
-	opts := map[string]string{
-		"encoding":        "json",
-		"stream-channels": "true",
-	}
-	return &RequestIPNS{
-		ApiBase: url + "/api/v0",
-		Command: command,
-		Args:    args,
-		Opts:    opts,
-		Headers: make(map[string]string),
-	}
-}
-
 type Response struct {
 	Output io.ReadCloser
 	Error  *Error
@@ -164,79 +137,6 @@ func (r *Request) getURL() string {
 	values := make(url.Values)
 	for _, arg := range r.Args {
 		values.Add("arg", arg)
-	}
-	for k, v := range r.Opts {
-		values.Add(k, v)
-	}
-
-	return fmt.Sprintf("%s/%s?%s", r.ApiBase, r.Command, values.Encode())
-}
-
-func (r *RequestIPNS) SendIPNS(c *http.Client) (*Response, error) {
-	url := r.getURLIPNS()
-	req, err := http.NewRequest("POST", url, r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if fr, ok := r.Body.(*files.MultiFileReader); ok {
-		req.Header.Set("Content-Type", "multipart/form-data; boundary="+fr.Boundary())
-		req.Header.Set("Content-Disposition", "form-data: name=\"files\"")
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	contentType := resp.Header.Get("Content-Type")
-	parts := strings.Split(contentType, ";")
-	contentType = parts[0]
-
-	nresp := new(Response)
-
-	nresp.Output = resp.Body
-	if resp.StatusCode >= http.StatusBadRequest {
-		e := &Error{
-			Command: r.Command,
-		}
-		switch {
-		case resp.StatusCode == http.StatusNotFound:
-			e.Message = "command not found"
-		case contentType == "text/plain":
-			out, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ipfs-shell: warning! response read error: %s\n", err)
-			}
-			e.Message = string(out)
-		case contentType == "application/json":
-			if err = json.NewDecoder(resp.Body).Decode(e); err != nil {
-				fmt.Fprintf(os.Stderr, "ipfs-shell: warning! response unmarshall error: %s\n", err)
-			}
-		default:
-			fmt.Fprintf(os.Stderr, "ipfs-shell: warning! unhandled response encoding: %s", contentType)
-			out, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ipfs-shell: response read error: %s\n", err)
-			}
-			e.Message = fmt.Sprintf("unknown ipfs-shell error encoding: %q - %q", contentType, out)
-		}
-		nresp.Error = e
-		nresp.Output = nil
-
-		// drain body and close
-		ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-	}
-
-	return nresp, nil
-}
-
-func (r *RequestIPNS) getURLIPNS() string {
-
-	values := make(url.Values)
-	for k, arg := range r.Args {
-		values.Add(k, arg)
 	}
 	for k, v := range r.Opts {
 		values.Add(k, v)

--- a/shell.go
+++ b/shell.go
@@ -92,10 +92,6 @@ func (s *Shell) newRequest(ctx context.Context, command string, args ...string) 
 	return NewRequest(ctx, s.url, command, args...)
 }
 
-func (s *Shell) newRequestIPNS(ctx context.Context, command string, args map[string]string) *RequestIPNS {
-	return NewRequestIPNS(ctx, s.url, command, args)
-}
-
 type IdOutput struct {
 	ID              string
 	PublicKey       string

--- a/shell.go
+++ b/shell.go
@@ -92,6 +92,10 @@ func (s *Shell) newRequest(ctx context.Context, command string, args ...string) 
 	return NewRequest(ctx, s.url, command, args...)
 }
 
+func (s *Shell) newRequestIPNS(ctx context.Context, command string, args map[string]string) *RequestIPNS {
+	return NewRequestIPNS(ctx, s.url, command, args)
+}
+
 type IdOutput struct {
 	ID              string
 	PublicKey       string


### PR DESCRIPTION
Hello,

I recently ran into an issue with go-ipfs-api where I wanted additional control over IPNS record publishing (key specification, ttl, etc..., retrieving the response) so I have created an additional function `PublishWithDetails`, which returns the response from the IPFS daemon as well as allows for manipulation of the api parameters.