### PR TITLE
Add Headers that were specified in the RequestBuilder.

### DIFF
--- a/request.go
+++ b/request.go
@@ -88,6 +88,11 @@ func (r *Request) Send(c *http.Client) (*Response, error) {
 		return nil, err
 	}
 
+	// Add any headers that were supplied via the RequestBuilder.
+	for k, v := range r.Headers {
+		req.Header.Add(k, v)
+	}
+
 	if fr, ok := r.Body.(*files.MultiFileReader); ok {
 		req.Header.Set("Content-Type", "multipart/form-data; boundary="+fr.Boundary())
 		req.Header.Set("Content-Disposition", "form-data: name=\"files\"")


### PR DESCRIPTION
RequestBuilder allows you to specify headers. These are passed all the way down to the Send() method in request.go, but then they are not added to the actual http request. This pull request adds those headers. I need this to add an auth header.