### PR TITLE
remove the go-libp2p-pubsub dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,6 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmRcFemyJ8JjkMhErTAapQqs411JxD6YQRbtCmwAfnGe24",
-      "name": "go-libp2p-pubsub",
-      "version": "0.1.1"
-    },
-    {
-      "author": "whyrusleeping",
       "hash": "QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W",
       "name": "go-libp2p-peer",
       "version": "2.3.7"

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,57 +1,17 @@
 package shell
 
 import (
-	"encoding/binary"
 	"encoding/json"
 
 	"github.com/libp2p/go-libp2p-peer"
-	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )
 
-// PubSubRecord is a record received via PubSub.
-type PubSubRecord interface {
-	// From returns the peer ID of the node that published this record
-	From() peer.ID
-
-	// Data returns the data field
-	Data() []byte
-
-	// SeqNo is the sequence number of this record
-	SeqNo() int64
-
-	//TopicIDs is the list of topics this record belongs to
-	TopicIDs() []string
+type Message struct {
+	From     peer.ID  `json:"from,omitempty"`
+	Data     []byte   `json:"data,omitempty"`
+	Seqno    []byte   `json:"seqno,omitempty"`
+	TopicIDs []string `json:"topicIDs,omitempty"`
 }
-
-type message struct {
-	*pb.Message
-}
-
-func (m *message) GetFrom() peer.ID {
-	return peer.ID(m.Message.GetFrom())
-}
-
-type floodsubRecord struct {
-	msg *message
-}
-
-func (r floodsubRecord) From() peer.ID {
-	return r.msg.GetFrom()
-}
-
-func (r floodsubRecord) Data() []byte {
-	return r.msg.GetData()
-}
-
-func (r floodsubRecord) SeqNo() int64 {
-	return int64(binary.BigEndian.Uint64(r.msg.GetSeqno()))
-}
-
-func (r floodsubRecord) TopicIDs() []string {
-	return r.msg.GetTopicIDs()
-}
-
-///
 
 // PubSubSubscription allow you to receive pubsub records that where published on the network.
 type PubSubSubscription struct {
@@ -67,17 +27,17 @@ func newPubSubSubscription(resp *Response) *PubSubSubscription {
 }
 
 // Next waits for the next record and returns that.
-func (s *PubSubSubscription) Next() (PubSubRecord, error) {
+func (s *PubSubSubscription) Next() (*Message, error) {
 	if s.resp.Error != nil {
 		return nil, s.resp.Error
 	}
 
 	d := json.NewDecoder(s.resp.Output)
 
-	r := &message{}
-	err := d.Decode(r)
+	var r Message
+	err := d.Decode(&r)
 
-	return floodsubRecord{msg: r}, err
+	return &r, err
 }
 
 // Cancel cancels the given subscription.

--- a/shell_test.go
+++ b/shell_test.go
@@ -203,7 +203,7 @@ func TestPubSub(t *testing.T) {
 
 	is.Nil(err)
 	is.NotNil(r)
-	is.Equal(r.Data(), "Hello World!")
+	is.Equal(r.Data, "Hello World!")
 
 	sub2, err := s.PubSubSubscribe(topic)
 	is.Nil(err)
@@ -214,12 +214,12 @@ func TestPubSub(t *testing.T) {
 	r, err = sub2.Next()
 	is.Nil(err)
 	is.NotNil(r)
-	is.Equal(r.Data(), "Hallo Welt!")
+	is.Equal(r.Data, "Hallo Welt!")
 
 	r, err = sub.Next()
 	is.NotNil(r)
 	is.Nil(err)
-	is.Equal(r.Data(), "Hallo Welt!")
+	is.Equal(r.Data, "Hallo Welt!")
 
 	is.Nil(sub.Cancel())
 }


### PR DESCRIPTION
We don't actually need to use the struct definitions from go-libp2p-pubsub. The interface is part of the API so we should be able to just re-implement them here.

This *is* a breaking change: I've removed the interface and replaced it with a bare struct. IMO, that's *significantly* more idiomatic. `SeqNo()` needed to be changed *anyways* as we can't guarantee that sequence numbers are *just* numbers, they can be anything. The existing code would have crashed when run against js-ipfs, as far as I could tell.