### PR TITLE
gx: update to use extracted go-ipfs-files

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	files "github.com/ipfs/go-ipfs-cmdkit/files"
+	files "github.com/ipfs/go-ipfs-files"
 )
 
 func (s *Shell) DagGet(ref string, out interface{}) error {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,6 @@
       "version": "1.6.3"
     },
     {
-      "author": "keks",
-      "hash": "QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky",
-      "name": "go-ipfs-cmdkit",
-      "version": "1.1.3"
-    },
-    {
       "author": "mitchellh",
       "hash": "QmdcULN1WCzgoQmcCaUAmEhwcxHYsDrbZ2LvRJKCL8dMrK",
       "name": "go-homedir",
@@ -54,6 +48,12 @@
       "hash": "QmdhwKw53CTV8EJSAsR1bpmMT5kXiWBgeAyv1EXeeDiXqR",
       "name": "go-libp2p-metrics",
       "version": "2.1.5"
+    },
+    {
+      "author": "magik6k",
+      "hash": "QmPPTbdBVPWgSwtDzL4ftVc5E3TH32oUtnov3RFNwbEoR4",
+      "name": "go-ipfs-files",
+      "version": "1.0.0"
     }
   ],
   "gxVersion": "0.7.0",

--- a/request.go
+++ b/request.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	files "github.com/ipfs/go-ipfs-cmdkit/files"
+	files "github.com/ipfs/go-ipfs-files"
 )
 
 type Request struct {

--- a/shell.go
+++ b/shell.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	files "github.com/ipfs/go-ipfs-cmdkit/files"
+	files "github.com/ipfs/go-ipfs-files"
 	homedir "github.com/mitchellh/go-homedir"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"


### PR DESCRIPTION
Apparently breaking code breaks gx on jenkins