### PR TITLE
shell: pass in create instead of hard-code

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -291,7 +291,7 @@ func (s *Shell) PatchData(root string, set bool, data interface{}) (string, erro
 func (s *Shell) PatchLink(root, path, childhash string, create bool) (string, error) {
 	var out object
 	return out.Hash, s.Request("object/patch/add-link", root, path, childhash).
-		Option("create", true).
+		Option("create", create).
 		Exec(context.Background(), &out)
 }
 


### PR DESCRIPTION
In `Shell::Create` you can specify whether or not to create intermediary nodes. At the moment, instead of letting the user toggle whether or not to create them, it defaults to `true`, this allows the user to decide whether or not to create, as opposed to the current hard-coded `true`.