### PR TITLE
Add Test for PatchLink for create == false

### DIFF
--- a/shell_test.go
+++ b/shell_test.go
@@ -229,6 +229,13 @@ func TestPatchLink(t *testing.T) {
 	newRoot, err = s.PatchLink(examplesHash, "about", "QmUXTtySmd7LD4p6RG6rZW6RuUuPZXTtNMmRQ6DSQo3aMw", false)
 	is.Nil(err)
 	is.Equal(newRoot, "QmVfe7gesXf4t9JzWePqqib8QSifC1ypRBGeJHitSnF7fA")
+	newHash, err := s.NewObject("unixfs-dir")
+	is.Nil(err)
+	_, err = s.PatchLink(newHash, "a/b/c", newHash, false)
+	is.NotNil(err)
+	newHash, err = s.PatchLink(newHash, "a/b/c", newHash, true)
+	is.Nil(err)
+	is.Equal(newHash, "QmQ5D3xbMWFQRC9BKqbvnSnHri31GqvtWG1G6rE8xAZf1J")
 }
 
 func TestResolvePath(t *testing.T) {

--- a/shell_test.go
+++ b/shell_test.go
@@ -223,8 +223,10 @@ func TestPatch_rmLink(t *testing.T) {
 func TestPatchLink(t *testing.T) {
 	is := is.New(t)
 	s := NewShell(shellUrl)
-
 	newRoot, err := s.PatchLink(examplesHash, "about", "QmUXTtySmd7LD4p6RG6rZW6RuUuPZXTtNMmRQ6DSQo3aMw", true)
+	is.Nil(err)
+	is.Equal(newRoot, "QmVfe7gesXf4t9JzWePqqib8QSifC1ypRBGeJHitSnF7fA")
+	newRoot, err = s.PatchLink(examplesHash, "about", "QmUXTtySmd7LD4p6RG6rZW6RuUuPZXTtNMmRQ6DSQo3aMw", false)
 	is.Nil(err)
 	is.Equal(newRoot, "QmVfe7gesXf4t9JzWePqqib8QSifC1ypRBGeJHitSnF7fA")
 }


### PR DESCRIPTION
While writing this test, it became apparent that whether or not you create intermediary nodes, the resulting root hash is the same. What exactly is the effect of creating/not-creating the intermediary nodes? If there is a big difference I should be able to expand the test to check whether or not the intermediary nodes were created, however I'm not quite able to ascertain what the difference is.

Adds a test for [pull/143](https://github.com/ipfs/go-ipfs-api/pull/143)