### PR TITLE
Add error checking on message decode, change Message.From to []byte, remove dependency on libp2p-peer

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -2,12 +2,10 @@ package shell
 
 import (
 	"encoding/json"
-
-	"github.com/libp2p/go-libp2p-peer"
 )
 
 type Message struct {
-	From     peer.ID  `json:"from,omitempty"`
+	From     []byte  `json:"from,omitempty"`
 	Data     []byte   `json:"data,omitempty"`
 	Seqno    []byte   `json:"seqno,omitempty"`
 	TopicIDs []string `json:"topicIDs,omitempty"`
@@ -36,6 +34,9 @@ func (s *PubSubSubscription) Next() (*Message, error) {
 
 	var r Message
 	err := d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
 
 	return &r, err
 }


### PR DESCRIPTION
Message.From is serialized as []byte. This fixes the following test failure:
``	shell_test.go:149: {QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V about 1677 2} != {QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V about 1688 2}
--- FAIL: TestList (0.00s)
	shell_test.go:278: expected nil: &errors.errorString{s:"input isn't valid multihash"}
--- FAIL: TestPubSub (0.01s)
    shell_test.go:262: subscribing...
    shell_test.go:266: sub: done
    shell_test.go:270: publishing...
    shell_test.go:272: pub: done
    shell_test.go:274: next()...
    shell_test.go:276: next: done. 
FAIL
exit status 1
``