### PR TITLE
correctly decode the peer ID

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -6,11 +6,12 @@ import (
 	"github.com/libp2p/go-libp2p-peer"
 )
 
+// Message is a pubsub message.
 type Message struct {
-	From     peer.ID  `json:"from,omitempty"`
-	Data     []byte   `json:"data,omitempty"`
-	Seqno    []byte   `json:"seqno,omitempty"`
-	TopicIDs []string `json:"topicIDs,omitempty"`
+	From     peer.ID
+	Data     []byte
+	Seqno    []byte
+	TopicIDs []string
 }
 
 // PubSubSubscription allow you to receive pubsub records that where published on the network.
@@ -34,10 +35,28 @@ func (s *PubSubSubscription) Next() (*Message, error) {
 
 	d := json.NewDecoder(s.resp.Output)
 
-	var r Message
-	err := d.Decode(&r)
+	var r struct {
+		From     []byte   `json:"from,omitempty"`
+		Data     []byte   `json:"data,omitempty"`
+		Seqno    []byte   `json:"seqno,omitempty"`
+		TopicIDs []string `json:"topicIDs,omitempty"`
+	}
 
-	return &r, err
+	err := d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+
+	from, err := peer.IDFromBytes(r.From)
+	if err != nil {
+		return nil, err
+	}
+	return &Message{
+		From:     from,
+		Data:     r.Data,
+		Seqno:    r.Seqno,
+		TopicIDs: r.TopicIDs,
+	}, nil
 }
 
 // Cancel cancels the given subscription.

--- a/shell_test.go
+++ b/shell_test.go
@@ -134,13 +134,13 @@ func TestList(t *testing.T) {
 
 	// TODO: document difference in size between 'ipfs ls' and 'ipfs file ls -v'. additional object encoding in data block?
 	expected := map[string]LsLink{
-		"about":          {Type: TFile, Hash: "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V", Name: "about", Size: 1688},
-		"contact":        {Type: TFile, Hash: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", Name: "contact", Size: 200},
-		"help":           {Type: TFile, Hash: "QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7", Name: "help", Size: 322},
-		"ping":           {Type: TFile, Hash: "QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y", Name: "ping", Size: 12},
-		"quick-start":    {Type: TFile, Hash: "QmXgqKTbzdh83pQtKFb19SpMCpDDcKR2ujqk3pKph9aCNF", Name: "quick-start", Size: 1692},
-		"readme":         {Type: TFile, Hash: "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB", Name: "readme", Size: 1102},
-		"security-notes": {Type: TFile, Hash: "QmQ5vhrL7uv6tuoN9KeVBwd4PwfQkXdVVmDLUZuTNxqgvm", Name: "security-notes", Size: 1173},
+		"about":          {Type: TFile, Hash: "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V", Name: "about", Size: 1677},
+		"contact":        {Type: TFile, Hash: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", Name: "contact", Size: 189},
+		"help":           {Type: TFile, Hash: "QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7", Name: "help", Size: 311},
+		"ping":           {Type: TFile, Hash: "QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y", Name: "ping", Size: 4},
+		"quick-start":    {Type: TFile, Hash: "QmXgqKTbzdh83pQtKFb19SpMCpDDcKR2ujqk3pKph9aCNF", Name: "quick-start", Size: 1681},
+		"readme":         {Type: TFile, Hash: "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB", Name: "readme", Size: 1091},
+		"security-notes": {Type: TFile, Hash: "QmQ5vhrL7uv6tuoN9KeVBwd4PwfQkXdVVmDLUZuTNxqgvm", Name: "security-notes", Size: 1162},
 	}
 	for _, l := range list {
 		el, ok := expected[l.Name]


### PR DESCRIPTION
Otherwise, we cast the base64 encoded string to a peer ID (which isn't valid).