### PR TITLE
error on redirect

### DIFF
--- a/requestbuilder.go
+++ b/requestbuilder.go
@@ -78,7 +78,7 @@ func (r *RequestBuilder) Send(ctx context.Context) (*Response, error) {
 	req.Opts = r.opts
 	req.Headers = r.headers
 	req.Body = r.body
-	return req.Send(r.shell.httpcli)
+	return req.Send(&r.shell.httpcli)
 }
 
 // Exec sends the request a request and decodes the response.

--- a/shell.go
+++ b/shell.go
@@ -33,7 +33,7 @@ const (
 
 type Shell struct {
 	url     string
-	httpcli *gohttp.Client
+	httpcli gohttp.Client
 }
 
 func NewLocalShell() *Shell {
@@ -79,11 +79,13 @@ func NewShellWithClient(url string, c *gohttp.Client) *Shell {
 			url = host
 		}
 	}
-
-	return &Shell{
-		url:     url,
-		httpcli: c,
+	var sh Shell
+	sh.url = url
+	// We don't support redirects.
+	sh.httpcli.CheckRedirect = func(_ *gohttp.Request, _ []*gohttp.Request) error {
+		return fmt.Errorf("unexpected redirect")
 	}
+	return &sh
 }
 
 func (s *Shell) SetTimeout(d time.Duration) {

--- a/shell_test.go
+++ b/shell_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,17 @@ func TestAdd(t *testing.T) {
 	mhash, err := s.Add(bytes.NewBufferString("Hello IPFS Shell tests"))
 	is.Nil(err)
 	is.Equal(mhash, "QmUfZ9rAdhV5ioBzXKdUTh2ZNsz9bzbkaLVyQ8uc8pj21F")
+}
+
+func TestRedirect(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	err := s.
+		Request("/version").
+		Exec(context.Background(), nil)
+	is.NotNil(err)
+	is.True(strings.Contains(err.Error(), "unexpected redirect"))
 }
 
 func TestAddWithCat(t *testing.T) {


### PR DESCRIPTION
Unfortunately, we can't handle redirects as we may have read from some request
body and can't start over. This disables redirects and informs the user.

fixes #159