### PR TITLE
handle late errors when ignoring the response value

### DIFF
--- a/request.go
+++ b/request.go
@@ -68,8 +68,14 @@ type Response struct {
 func (r *Response) Close() error {
 	if r.Output != nil {
 		// always drain output (response body)
-		ioutil.ReadAll(r.Output)
-		return r.Output.Close()
+		_, err1 := io.Copy(ioutil.Discard, r.Output)
+		err2 := r.Output.Close()
+		if err1 != nil {
+			return err1
+		}
+		if err2 != nil {
+			return err2
+		}
 	}
 	return nil
 }

--- a/request.go
+++ b/request.go
@@ -164,7 +164,7 @@ func (r *Request) Send(c *http.Client) (*Response, error) {
 		nresp.Output = nil
 
 		// drain body and close
-		ioutil.ReadAll(resp.Body)
+		io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 	}
 

--- a/requestbuilder.go
+++ b/requestbuilder.go
@@ -89,11 +89,11 @@ func (r *RequestBuilder) Exec(ctx context.Context, res interface{}) error {
 	}
 
 	if res == nil {
-		httpRes.Close()
+		lateErr := httpRes.Close()
 		if httpRes.Error != nil {
 			return httpRes.Error
 		}
-		return nil
+		return lateErr
 	}
 
 	return httpRes.Decode(res)


### PR DESCRIPTION
We return trailing errors from the reader.