### PR TITLE
Fix Content-Disposition HTTP header

### DIFF
--- a/request.go
+++ b/request.go
@@ -120,7 +120,7 @@ func (r *Request) Send(c *http.Client) (*Response, error) {
 
 	if fr, ok := r.Body.(*files.MultiFileReader); ok {
 		req.Header.Set("Content-Type", "multipart/form-data; boundary="+fr.Boundary())
-		req.Header.Set("Content-Disposition", "form-data: name=\"files\"")
+		req.Header.Set("Content-Disposition", "form-data; name=\"files\"")
 	}
 
 	resp, err := c.Do(req)


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#As_a_response_header_for_the_main_body), parameters in the `Content-Disposition` HTTP header must be separated by a `;`.  `go-ipfs-api` use a `:` most likely a typo.

This break the parsing of `multipart/form-data` requests (say, `ipfs add`) with common HTTP library, one of them being golang's `http` package.