### PR TITLE
Add Log Tail Wrapper

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -25,13 +25,12 @@ func (l Logger) Close() error {
 
 // GetLogs is used to retrieve a parsable logger object
 func (s *Shell) GetLogs(ctx context.Context) (Logger, error) {
-
 	resp, err := s.Request("log/tail").Send(ctx)
 	if err != nil {
-		return Logger{}, nil
+		return Logger{}, err
 	}
 	if resp.Error != nil {
-		resp.Close()
+		resp.Output.Close()
 		return Logger{}, resp.Error
 	}
 	return newLogger(resp.Output), nil

--- a/logger.go
+++ b/logger.go
@@ -30,7 +30,7 @@ func (l Logger) Close() error {
 // GetLogs is used to retrieve a parsable logger object
 func (s *Shell) GetLogs() (Logger, error) {
 	var url string
-	if !strings.HasPrefix(s.url, "http://") {
+	if !strings.HasPrefix(s.url, "http://") || !strings.HasPrefix(s.url, "https://") {
 		url = fmt.Sprintf("http://%s/api/v0/log/tail", s.url)
 	} else {
 		url = s.url

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Logger is used to handle incoming logs from the ipfs node
@@ -28,8 +29,13 @@ func (l Logger) Close() error {
 
 // GetLogs is used to retrieve a parsable logger object
 func (s *Shell) GetLogs() (Logger, error) {
-	logURL := fmt.Sprintf("http://%s/api/v0/log/tail", s.url)
-	req, err := http.NewRequest("GET", logURL, nil)
+	var url string
+	if !strings.HasPrefix(s.url, "http://") {
+		url = fmt.Sprintf("http://%s/api/v0/log/tail", s.url)
+	} else {
+		url = s.url
+	}
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return Logger{}, err
 	}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,42 @@
+package shell
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Logger is used to handle incoming logs from the ipfs node
+type Logger struct {
+	r io.ReadCloser
+}
+
+// Next is used to retrieve the next event from the logging system
+func (l Logger) Next() (map[string]interface{}, error) {
+	var out map[string]interface{}
+	if err := json.NewDecoder(l.r).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Close is used to close our reader
+func (l Logger) Close() error {
+	return l.r.Close()
+}
+
+// GetLogs is used to retrieve a parsable logger object
+func (s *Shell) GetLogs() (Logger, error) {
+	logURL := fmt.Sprintf("http://%s/api/v0/log/tail", s.url)
+	req, err := http.NewRequest("GET", logURL, nil)
+	if err != nil {
+		return Logger{}, err
+	}
+	hc := &http.Client{}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return Logger{}, err
+	}
+	return Logger{resp.Body}, nil
+}

--- a/logger.go
+++ b/logger.go
@@ -1,48 +1,42 @@
 package shell
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"io"
-	"net/http"
-	"strings"
 )
 
 // Logger is used to handle incoming logs from the ipfs node
 type Logger struct {
-	r io.ReadCloser
+	resp io.ReadCloser
+	dec  *json.Decoder
 }
 
 // Next is used to retrieve the next event from the logging system
 func (l Logger) Next() (map[string]interface{}, error) {
 	var out map[string]interface{}
-	if err := json.NewDecoder(l.r).Decode(&out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	return out, l.dec.Decode(&out)
 }
 
 // Close is used to close our reader
 func (l Logger) Close() error {
-	return l.r.Close()
+	return l.resp.Close()
 }
 
 // GetLogs is used to retrieve a parsable logger object
-func (s *Shell) GetLogs() (Logger, error) {
-	var url string
-	if !strings.HasPrefix(s.url, "http://") || !strings.HasPrefix(s.url, "https://") {
-		url = fmt.Sprintf("http://%s/api/v0/log/tail", s.url)
-	} else {
-		url = s.url
-	}
-	req, err := http.NewRequest("GET", url, nil)
+func (s *Shell) GetLogs(ctx context.Context) (Logger, error) {
+
+	resp, err := s.Request("log/tail").Send(ctx)
 	if err != nil {
-		return Logger{}, err
+		return Logger{}, nil
 	}
-	hc := &http.Client{}
-	resp, err := hc.Do(req)
-	if err != nil {
-		return Logger{}, err
+	if resp.Error != nil {
+		resp.Close()
+		return Logger{}, resp.Error
 	}
-	return Logger{resp.Body}, nil
+	return newLogger(resp.Output), nil
+}
+
+func newLogger(resp io.ReadCloser) Logger {
+	return Logger{resp, json.NewDecoder(resp)}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,12 +1,15 @@
 package shell
 
 import (
+	"context"
 	"testing"
 )
 
 func Test_Logger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	sh := NewShell(shellUrl)
-	logger, err := sh.GetLogs()
+	logger, err := sh.GetLogs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_Logger(t *testing.T) {
+func TestLogger(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sh := NewShell(shellUrl)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,20 @@
+package shell
+
+import "testing"
+
+func Test_Logger(t *testing.T) {
+	sh := NewLocalShell()
+	logger, err := sh.GetLogs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := logger.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	_, err = logger.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Test_Logger(t *testing.T) {
-	sh := NewLocalShell()
+	sh := NewShell(shellUrl)
 	logger, err := sh.GetLogs()
 	if err != nil {
 		t.Fatal(err)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,6 +1,8 @@
 package shell
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_Logger(t *testing.T) {
 	sh := NewLocalShell()
@@ -13,8 +15,9 @@ func Test_Logger(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	_, err = logger.Next()
-	if err != nil {
+	if l, err := logger.Next(); err != nil {
 		t.Fatal(err)
+	} else if l == nil {
+		t.Fatal("no logs found")
 	}
 }


### PR DESCRIPTION
I needed this functionality to be able to tail ipfs logs for another project and figured it would probably be useful to others.

I tried using the built in request builder, however it appears that it just continually waits for the call to finish, and given that the `log/tail` call streams responses, so it just hangs.