### PR TITLE
Enable Multihash Selection When Using Add

### DIFF
--- a/add.go
+++ b/add.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ipfs/go-ipfs-files"
+	files "github.com/ipfs/go-ipfs-files"
 )
 
 type object struct {
@@ -41,6 +41,14 @@ func Progress(enabled bool) AddOpts {
 func RawLeaves(enabled bool) AddOpts {
 	return func(rb *RequestBuilder) error {
 		rb.Option("raw-leaves", enabled)
+		return nil
+	}
+}
+
+// Hash allows for selecting the multihash type
+func Hash(hash string) AddOpts {
+	return func(rb *RequestBuilder) error {
+		rb.Option("hash", hash)
 		return nil
 	}
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -28,6 +28,9 @@ func TestAdd(t *testing.T) {
 	mhash, err := s.Add(bytes.NewBufferString("Hello IPFS Shell tests"))
 	is.Nil(err)
 	is.Equal(mhash, "QmUfZ9rAdhV5ioBzXKdUTh2ZNsz9bzbkaLVyQ8uc8pj21F")
+	mhash, err = s.Add(bytes.NewBufferString("Hello IPFS Shell tests"), Hash("sha3-256"))
+	is.Nil(err)
+	is.Equal(mhash, "zb2wwqxjxosf8GKEZCwAWSFZ879XFNca3De5yAoh5b2axAffc")
 }
 
 func TestRedirect(t *testing.T) {


### PR DESCRIPTION
Enables the selection of the multihash type via an `AddOpts` type called `Hash`.