### PR TITLE
fix Error.Code never set

### DIFF
--- a/request.go
+++ b/request.go
@@ -142,6 +142,7 @@ func (r *Request) Send(c *http.Client) (*Response, error) {
 	if resp.StatusCode >= http.StatusBadRequest {
 		e := &Error{
 			Command: r.Command,
+			Code:    resp.StatusCode,
 		}
 		switch {
 		case resp.StatusCode == http.StatusNotFound:


### PR DESCRIPTION
When a request fail, `Error.Code` was never set, which is especially if the API can be throttled with the HTTP 429 status code.

This PR fix that problem.