### PR TITLE
Add Unix Domain Socket support to Shell client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.11.x
+  - 1.13.x
 
 services:
   - docker

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+go 1.13
+
 module github.com/ipfs/go-ipfs-api
 
 require (


### PR DESCRIPTION
Add uds support to shell, in order to have something like 
`shell := NewShell("/unix//tmp/sock")`  working

I don't know if it's really pertinent, but I add a simple test that try to create a shell with `/unix/<sockpath>` and make a request to a simple http server listening on the same sock.

I also manually tested the shell against a real ipfs node with:
```diff
modified   shell_test.go
@@ -18,7 +18,7 @@ import (
-	shellUrl     = "localhost:5001"
+	shellUrl     = "/unix//tmp/sock"
 )
```
and using `/unix//tmp/sock` as IPFS API listener
