### PR TITLE
Added Type field for Pin ls command

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -240,9 +240,9 @@ func (s *Shell) Pins() (map[string]PinInfo, error) {
 }
 
 // Pins returns a map of the pins of specified type (DirectPin, RecursivePin, or IndirectPin)
-func (s *Shell) PinsOfType(pinType PinType) (map[string]PinInfo, error) {
+func (s *Shell) PinsOfType(ctx context.Context, pinType PinType) (map[string]PinInfo, error) {
 	var raw struct{ Keys map[string]PinInfo }
-	return raw.Keys, s.Request("pin/ls").Option("type", pinType).Exec(context.Background(), &raw)
+	return raw.Keys, s.Request("pin/ls").Option("type", pinType).Exec(ctx, &raw)
 }
 
 // PinStreamInfo is the output type for PinsStream

--- a/shell.go
+++ b/shell.go
@@ -217,10 +217,12 @@ func (s *Shell) Unpin(path string) error {
 		Exec(context.Background(), nil)
 }
 
+type PinType string
+
 const (
-	DirectPin    = "direct"
-	RecursivePin = "recursive"
-	IndirectPin  = "indirect"
+	DirectPin    PinType = "direct"
+	RecursivePin PinType = "recursive"
+	IndirectPin  PinType = "indirect"
 )
 
 type PinInfo struct {
@@ -235,6 +237,12 @@ type PinInfo struct {
 func (s *Shell) Pins() (map[string]PinInfo, error) {
 	var raw struct{ Keys map[string]PinInfo }
 	return raw.Keys, s.Request("pin/ls").Exec(context.Background(), &raw)
+}
+
+// Pins returns a map of the pins of specified type (DirectPin, RecursivePin, or IndirectPin)
+func (s *Shell) PinsOfType(pinType PinType) (map[string]PinInfo, error) {
+	var raw struct{ Keys map[string]PinInfo }
+	return raw.Keys, s.Request("pin/ls").Option("type", pinType).Exec(context.Background(), &raw)
 }
 
 // PinStreamInfo is the output type for PinsStream

--- a/shell_test.go
+++ b/shell_test.go
@@ -247,7 +247,7 @@ func TestPinsOfType(t *testing.T) {
 	h, err := s.Add(bytes.NewBufferString("go-ipfs-api pins test 9F3D1F30-D12A-4024-9477-8F0C8E4B3A63"))
 	is.Nil(err)
 
-	pins, err := s.PinsOfType(RecursivePin)
+	pins, err := s.PinsOfType(context.Background(), RecursivePin)
 	is.Nil(err)
 
 	_, ok := pins[h]

--- a/shell_test.go
+++ b/shell_test.go
@@ -239,6 +239,40 @@ func TestPins(t *testing.T) {
 	is.Equal(info.Type, RecursivePin)
 }
 
+func TestPinsOfType(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	// Add a thing, which pins it by default
+	h, err := s.Add(bytes.NewBufferString("go-ipfs-api pins test 9F3D1F30-D12A-4024-9477-8F0C8E4B3A63"))
+	is.Nil(err)
+
+	pins, err := s.PinsOfType(RecursivePin)
+	is.Nil(err)
+
+	_, ok := pins[h]
+	is.True(ok)
+
+	err = s.Unpin(h)
+	is.Nil(err)
+
+	pins, err = s.Pins()
+	is.Nil(err)
+
+	_, ok = pins[h]
+	is.False(ok)
+
+	err = s.Pin(h)
+	is.Nil(err)
+
+	pins, err = s.Pins()
+	is.Nil(err)
+
+	info, ok := pins[h]
+	is.True(ok)
+	is.Equal(info.Type, RecursivePin)
+}
+
 func TestPinsStream(t *testing.T) {
 	is := is.New(t)
 	s := NewShell(shellUrl)


### PR DESCRIPTION
Close #237 

## Why:
I was thinking about ways to restrict the possible values for `PinType`, but could not come up with any nice ways, any suggestions would be appreciated.  
Also did not add check for restricting values of `PinType` in `PinsOfType`, because API returns with a very descriptive error for invalid `PinType` values.