### PR TITLE
Fix go.mod dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,5 @@ require (
 	github.com/libp2p/go-libp2p-core v0.6.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.0
-	github.com/multiformats/go-multiaddr-net v0.2.0
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c
 )


### PR DESCRIPTION
Dependency `multiformats/go-multiaddr-net v0.2.0` is deprecated and it has no particular use in this project, thus safely can be removed. This dependency causes error on `go get` and prevents package installation. This PR removes the dependency and thus fixes the proposed issue.
A version bump to v0.2.1 would be ok after the merge.  