### PR TITLE
chore: use common ipfs/start-ipfs-daemon-action in go-test-setup

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -7,9 +7,6 @@ runs:
     - name: Install go-ipfs
       shell: bash
       run: (cd /tmp && go install github.com/ipfs/go-ipfs/cmd/ipfs@master)
-    - name: Initialize go-ipfs
-      shell: bash
-      run: (ipfs init)
-    - name: Run go-ipfs
-      shell: bash
-      run: (ipfs daemon --enable-pubsub-experiment &)
+    - uses: ipfs/start-ipfs-daemon-action@v1
+      with:
+        args: --init --enable-pubsub-experiment


### PR DESCRIPTION
I want to replace the ipfs init and ipfs daemon calls here with a common action(https://github.com/ipfs/start-ipfs-daemon-action) to minimise duplication. This is part of work related to this issue: https://github.com/ipfs/go-ipfs/issues/8511

The workflow passes after the changes introduced by me: https://github.com/ipfs/go-ipfs-api/actions/runs/1579095670