### PR TITLE
Add ls and add swarming commands

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -611,3 +611,26 @@ func (s *Shell) SwarmConnect(ctx context.Context, addr ...string) error {
 		Exec(ctx, &conn)
 	return err
 }
+
+type PeeringLsOutput struct {
+	Peers []PeerInfo
+}
+
+// SwarmPeeringLs lists peers registered in the peering subsystem
+func (s *Shell) SwarmPeeringLs(ctx context.Context) (*PeeringLsOutput, error) {
+	var output *PeeringLsOutput
+	err := s.Request("swarm/peering/ls").Arguments().Exec(ctx, &output)
+	return output, err
+}
+
+type PeerStatus struct {
+	ID     string
+	Status string
+}
+
+// SwarmPeeringAdd adds a peer into the peering subsysytem.
+func (s *Shell) SwarmPeeringAdd(ctx context.Context, addr string) (*PeerStatus, error) {
+	var output *PeerStatus
+	err := s.Request("swarm/peering/add").Arguments(addr).Exec(ctx, &output)
+	return output, err
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -552,3 +552,18 @@ func TestRefs(t *testing.T) {
 	sort.Strings(actual)
 	is.Equal(expected, actual)
 }
+
+func TestSwarmPeeringLs(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+	_, err := s.SwarmPeeringLs(context.Background())
+	is.Nil(err)
+}
+
+func TestSwarmPeeringAdd(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+	addr := fmt.Sprintf("/ip4/10.10.10.10/tcp/4001/p2p/%s", examplesHash)
+	_, err := s.SwarmPeeringAdd(context.Background(), addr)
+	is.Nil(err)
+}


### PR DESCRIPTION
This PR adds the [/swarm/peering/ls](https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-swarm-peering-ls) and [/swarm/peering/add](https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-swarm-peering-add) commands. I'm working on a project where these commands would be really useful so putting this PR up for consideration.

In order to test, I pulled down [ipfs/kubo](https://github.com/ipfs/kubo), ran `docker compose up`, and ran the `shell_test.go` against the container.