### PR TITLE
feat: add missing "parents" option to FilesCp command

### DIFF
--- a/mfs.go
+++ b/mfs.go
@@ -41,6 +41,7 @@ type filesMkdir struct{}
 type filesRead struct{}
 type filesWrite struct{}
 type filesStat struct{}
+type filesCp struct{}
 
 var (
 	FilesLs    filesLs
@@ -49,6 +50,7 @@ var (
 	FilesRead  filesRead
 	FilesWrite filesWrite
 	FilesStat  filesStat
+	FilesCp    filesCp
 )
 
 // Stat use long listing format
@@ -203,6 +205,14 @@ func (filesWrite) Hash(hash string) FilesOpt {
 	}
 }
 
+// Parents make parent directories as needed
+func (filesCp) Parents(parents bool) FilesOpt {
+	return func(rb *RequestBuilder) error {
+		rb.Option("parents", parents)
+		return nil
+	}
+}
+
 // FilesChcid change the cid version or hash function of the root node of a given path
 func (s *Shell) FilesChcid(ctx context.Context, path string, options ...FilesOpt) error {
 	if len(path) == 0 {
@@ -220,8 +230,14 @@ func (s *Shell) FilesChcid(ctx context.Context, path string, options ...FilesOpt
 }
 
 // FilesCp copy any IPFS files and directories into MFS (or copy within MFS)
-func (s *Shell) FilesCp(ctx context.Context, src string, dest string) error {
-	return s.Request("files/cp", src, dest).Exec(ctx, nil)
+func (s *Shell) FilesCp(ctx context.Context, src string, dest string, options ...FilesOpt) error {
+	rb := s.Request("files/cp", src, dest)
+	for _, opt := range options {
+		if err := opt(rb); err != nil {
+			return err
+		}
+	}
+	return rb.Exec(ctx, nil)
 }
 
 // FilesFlush flush a given path's data to disk

--- a/mfs_test.go
+++ b/mfs_test.go
@@ -82,6 +82,21 @@ func TestFilesCp(t *testing.T) {
 	is.Nil(err)
 }
 
+func TestFilesCParents(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	err := s.FilesCp(context.Background(), "/testdata/readme", "/dirs/should/be/created/readme", FilesCp.Parents(true))
+	is.Nil(err)
+
+	stat, err := s.FilesStat(context.Background(), "/dirs/should/be/created/readme")
+	is.Nil(err)
+	is.Equal(stat.Hash, "QmfZt7xPekp7npSM6DHDUnFseAiNZQs7wq6muH9o99RsCB")
+
+	err = s.FilesRm(context.Background(), "/dirs/should/be/created/readme", true)
+	is.Nil(err)
+}
+
 func TestFilesFlush(t *testing.T) {
 	is := is.New(t)
 	s := NewShell(shellUrl)


### PR DESCRIPTION
Hi, I noticed an option is missing so I've added it. If you consider this useful, please accept this PR

Signed-off-by: vkost <viktor.kostadinov@gmail.com>