### PR TITLE
fix: topic list append

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -58,12 +58,12 @@ func (s *PubSubSubscription) Next() (*Message, error) {
 		return nil, err
 	}
 	topics := make([]string, len(r.TopicIDs))
-	for _, mbtopic := range r.TopicIDs {
+	for i, mbtopic := range r.TopicIDs {
 		_, topic, err := mbase.Decode(mbtopic)
 		if err != nil {
 			return nil, err
 		}
-		topics = append(topics, string(topic))
+		topics[i] = string(topic)
 	}
 	return &Message{
 		From:     from,


### PR DESCRIPTION
Topic is appending after the length of topics in the slice, causing it to waste space.