### PR TITLE
feat: add options to AddDir

### DIFF
--- a/shell_test.go
+++ b/shell_test.go
@@ -125,6 +125,16 @@ func TestAddDir(t *testing.T) {
 	is.Equal(cid, "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv")
 }
 
+func TestAddDirWithCidV1(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	cid, err := s.AddDir("./testdata", CidVersion(1))
+	is.Nil(err)
+	is.Equal(cid, "bafkreigxlgc3tzlfmfstpdrkfblo34ijlkvrzinvwdmi5agbgcpcmyelre")
+
+}
+
 func TestAddDirOffline(t *testing.T) {
 	is := is.New(t)
 	s := NewShell("0.0.0.0:1234") // connect to an invalid address

--- a/shell_test.go
+++ b/shell_test.go
@@ -131,8 +131,7 @@ func TestAddDirWithCidV1(t *testing.T) {
 
 	cid, err := s.AddDir("./testdata", CidVersion(1))
 	is.Nil(err)
-	is.Equal(cid, "bafkreigxlgc3tzlfmfstpdrkfblo34ijlkvrzinvwdmi5agbgcpcmyelre")
-
+	is.Equal(cid, "bafybeibgegl5yqme2jehvvneapbq7he5ahi3tmk4cpmlagrggeji6hzayq")
 }
 
 func TestAddDirOffline(t *testing.T) {


### PR DESCRIPTION
This PR modifies the AddDir function to accept AddOpts. A test function in `shell_test.go` called TestAddDirWithCidV1 has been included to ensure that CidVersion(1) works as an AddOpt.

See https://github.com/ipfs/go-ipfs-api/issues/276 for reference issue