### PR TITLE
Feat: add dag stat method

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 
 	files "github.com/ipfs/boxo/files"
@@ -228,7 +227,7 @@ func (s *Shell) DagStatWithOpts(data string, opts ...options.DagStatOption) (Dag
 		if err := dec.Decode(&v); err == io.EOF {
 			break
 		} else if err != nil {
-			log.Fatal(err)
+			return out, err
 		}
 		out = v
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ module github.com/ipfs/go-ipfs-api
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927
 	github.com/ipfs/boxo v0.8.0
+	github.com/ipfs/go-cid v0.4.0
 	github.com/libp2p/go-libp2p v0.26.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.8.0
@@ -16,7 +17,6 @@ require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
-	github.com/ipfs/go-cid v0.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect

--- a/options/dag_stat.go
+++ b/options/dag_stat.go
@@ -1,0 +1,33 @@
+package options
+
+// DagStatSettings is a set of Dag stat options.
+type DagStatSettings struct {
+	Progress bool
+}
+
+// DagStatOption is a single Dag option.
+type DagStatOption func(opts *DagStatSettings) error
+
+// DagStatOptions applies the given option to a DagStatSettings instance.
+func DagStatOptions(opts ...DagStatOption) (*DagStatSettings, error) {
+	options := &DagStatSettings{
+		Progress: false,
+	}
+
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return options, nil
+}
+
+// Progress is an option for Dag.Stat which returns progressive data while reading through the DAG
+func (dagOpts) Progress(progress bool) DagStatOption {
+	return func(opts *DagStatSettings) error {
+		opts.Progress = progress
+		return nil
+	}
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -630,3 +630,27 @@ func TestSwarmPeeringAdd(t *testing.T) {
 	_, err := s.SwarmPeeringAdd(context.Background(), addr)
 	is.Nil(err)
 }
+
+func TestDagStat(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	result, err := s.DagStat("QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB")
+	is.Nil(err)
+	is.Equal(result.TotalSize, 3383728)
+
+	is.Equal(result.DagStatsArray[0].Cid.String(), "QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB")
+	is.Equal(result.UniqueBlocks, 15)
+}
+
+func TestDagStatWithOpts(t *testing.T) {
+	is := is.New(t)
+	s := NewShell(shellUrl)
+
+	result, err := s.DagStatWithOpts("QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB", options.Dag.Progress(true))
+	is.Nil(err)
+	is.Equal(result.TotalSize, 3383728)
+
+	is.Equal(result.DagStatsArray[0].Cid.String(), "QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB")
+	is.Equal(result.UniqueBlocks, 15)
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -641,6 +641,9 @@ func TestDagStat(t *testing.T) {
 
 	is.Equal(result.DagStatsArray[0].Cid.String(), "QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB")
 	is.Equal(result.UniqueBlocks, 15)
+	is.Equal(result.redundantSize, 0)
+	is.Equal(result.SharedSize, 0)
+	is.Equal(result.Ratio, 1)
 }
 
 func TestDagStatWithOpts(t *testing.T) {
@@ -653,4 +656,7 @@ func TestDagStatWithOpts(t *testing.T) {
 
 	is.Equal(result.DagStatsArray[0].Cid.String(), "QmUwp4xYq4pt1xavfCnpJ2aoVETf83AsvK3W8KvUGtyzFB")
 	is.Equal(result.UniqueBlocks, 15)
+	is.Equal(result.redundantSize, 0)
+	is.Equal(result.SharedSize, 0)
+	is.Equal(result.Ratio, 1)
 }


### PR DESCRIPTION
As requested in [#286 ](https://github.com/ipfs/go-ipfs-api/issues/286), this PR includes `DagStat` method along with the Test functions.